### PR TITLE
Integrate league analyzer page and navigation

### DIFF
--- a/dh_0829/analyzer/analyzer.html
+++ b/dh_0829/analyzer/analyzer.html
@@ -154,15 +154,15 @@
             <p class="text-md text-gray-400">KTC Team Value Analysis</p>
         </header>
 
-        <!-- Controls -->
-        <div class="glass-panel py-1 px-2 flex flex-col md:flex-row items-center justify-center gap-1">
-            <input type="text" id="usernameInput" placeholder="Enter Sleeper Username" class="px-3 py-1 text-sm w-full md:w-auto">
-            <div id="leagueSelectWrapper" class="hidden w-full md:w-auto">
+        <!-- Controls hidden, values provided via query params -->
+        <div class="glass-panel py-1 px-2 flex flex-col md:flex-row items-center justify-center gap-1 hidden">
+            <input type="text" id="usernameInput" class="px-3 py-1 text-sm w-full md:w-auto">
+            <div id="leagueSelectWrapper" class="w-full md:w-auto">
                 <select id="leagueSelect" class="px-3 py-1 text-sm w-full md:w-auto appearance-none">
                     <option>Select a league...</option>
                 </select>
             </div>
-            <button id="fetchDataButton" class="bg-purple-600/50 hover:bg-purple-700/50 text-white font-bold text-sm py-1 px-3 w-full md:w-auto">Analyze League</button>
+            <button id="fetchDataButton" class="bg-purple-600/50 text-white font-bold text-sm py-1 px-3 w-full md:w-auto">Analyze League</button>
         </div>
         
         <!-- Summary Stats -->
@@ -251,14 +251,14 @@
 
 
             // --- Event Listeners ---
-            fetchDataButton.addEventListener('click', handleFetchData);
+            fetchDataButton.addEventListener('click', () => handleFetchData());
             leagueSelect.addEventListener('change', () => {
                 if (leagueSelect.value) {
                     analyzeLeague(leagueSelect.value);
                 }
             });
 
-            async function handleFetchData() {
+            async function handleFetchData(preselectedLeagueId = null) {
                 const username = usernameInput.value.trim();
                 if (!username) {
                     alert('Please enter a Sleeper username.');
@@ -279,9 +279,13 @@
                     await fetchUserAndLeagues(username);
 
                     if (state.leagues.length > 0) {
-                        // Auto-select and analyze the first league
-                        leagueSelect.selectedIndex = 1;
-                        await analyzeLeague(state.leagues[0].league_id);
+                        let idx = 0;
+                        if (preselectedLeagueId) {
+                            const found = state.leagues.findIndex(l => l.league_id === preselectedLeagueId);
+                            if (found !== -1) idx = found;
+                        }
+                        leagueSelect.selectedIndex = idx + 1;
+                        await analyzeLeague(state.leagues[idx].league_id);
                     }
                 } catch (error) {
                     console.error('Error fetching data:', error);
@@ -880,6 +884,14 @@
                     fetchDataButton.disabled = false;
                     fetchDataButton.textContent = 'Analyze League';
                 }
+            }
+
+            const params = new URLSearchParams(window.location.search);
+            const presetUsername = params.get('username');
+            const presetLeague = params.get('league');
+            if (presetUsername) {
+                usernameInput.value = presetUsername;
+                handleFetchData(presetLeague);
             }
         });
     </script>

--- a/dh_0829/index.html
+++ b/dh_0829/index.html
@@ -40,8 +40,7 @@
         <a href="index.html">Home</a>
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
-        <a href="#">Placeholder 1</a>
-        <a href="#">Placeholder 2</a>
+        <a href="#" id="menu-analyzer">League Analyzer</a>
     </div>
 </div>
 <div class="username-area">

--- a/dh_0829/ownership/ownership.html
+++ b/dh_0829/ownership/ownership.html
@@ -40,8 +40,7 @@
         <a href="../">Home</a>
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
-        <a href="#">Placeholder 1</a>
-        <a href="#">Placeholder 2</a>
+        <a href="#" id="menu-analyzer">League Analyzer</a>
     </div>
 </div>
 <div class="username-area">
@@ -62,6 +61,7 @@
 <div class="view-switcher secondary-switcher">
 <button id="positionalViewBtn">Positional</button>
 <button id="depthChartViewBtn">Lineup</button>
+<button id="analyzeButton">Analyze</button>
 </div>
 </div>
 <div class="header-row">

--- a/dh_0829/rosters/rosters.html
+++ b/dh_0829/rosters/rosters.html
@@ -40,8 +40,7 @@
         <a href="../">Home</a>
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
-        <a href="#">Placeholder 1</a>
-        <a href="#">Placeholder 2</a>
+        <a href="#" id="menu-analyzer">League Analyzer</a>
     </div>
 </div>
 <div class="username-area">
@@ -62,6 +61,7 @@
 <div class="view-switcher secondary-switcher">
 <button id="positionalViewBtn">Positional</button>
 <button id="depthChartViewBtn">Lineup</button>
+<button id="analyzeButton">Analyze</button>
 </div>
 </div>
 <div class="header-row">

--- a/dh_0829/scripts/app.js
+++ b/dh_0829/scripts/app.js
@@ -21,6 +21,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const clearCompareButton = document.getElementById('clearCompareButton');
         const positionalViewBtn = document.getElementById('positionalViewBtn');
         const depthChartViewBtn = document.getElementById('depthChartViewBtn');
+        const analyzeButton = document.getElementById('analyzeButton');
         const viewControls = document.getElementById('view-controls');
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const tradeSimulator = document.getElementById('tradeSimulator');
@@ -32,6 +33,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const dropdownMenu = document.getElementById('dropdown-menu');
         const menuRosters = document.getElementById('menu-rosters');
         const menuOwnership = document.getElementById('menu-ownership');
+        const menuAnalyzer = document.getElementById('menu-analyzer');
 
         menuButton?.addEventListener('click', (e) => {
             e.stopPropagation();
@@ -63,6 +65,15 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             } else {
                 handleFetchOwnership();
             }
+            dropdownMenu.classList.add('hidden');
+        });
+
+        menuAnalyzer?.addEventListener('click', () => {
+            const username = usernameInput.value.trim();
+            const leagueId = leagueSelect?.value;
+            if (!username || !leagueId) return;
+            const base = pageType === 'welcome' ? 'analyzer/analyzer.html' : '../analyzer/analyzer.html';
+            window.location.href = `${base}?username=${encodeURIComponent(username)}&league=${leagueId}`;
             dropdownMenu.classList.add('hidden');
         });
 
@@ -117,6 +128,14 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 window.location.href = `../rosters/rosters.html?username=${encodeURIComponent(username)}`;
             });
         }
+
+        analyzeButton?.addEventListener('click', () => {
+            const username = usernameInput.value.trim();
+            const leagueId = leagueSelect?.value;
+            if (!username || !leagueId) return;
+            const base = pageType === 'welcome' ? 'analyzer/analyzer.html' : '../analyzer/analyzer.html';
+            window.location.href = `${base}?username=${encodeURIComponent(username)}&league=${leagueId}`;
+        });
 
            leagueSelect?.addEventListener('change', (e) => {
           handleLeagueSelect(e);

--- a/dh_0829/styles/styles.css
+++ b/dh_0829/styles/styles.css
@@ -290,8 +290,8 @@
         .custom-select-wrapper {
             position: relative;
             flex-grow: 1;
-            min-width: 120px;
-            max-width: 150px;
+            min-width: 90px;
+            max-width: 120px;
         }
         #leagueSelect {
             appearance: none;


### PR DESCRIPTION
## Summary
- add League Analyzer option in menus
- include Analyze button alongside Positional and Lineup controls
- convert GEM_LG-IG.html into integrated analyzer page using existing league/username

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b244e54424832e9b51ef28e4aa2805