### PR TITLE
Add league analyzer integration and navigation

### DIFF
--- a/dh_0829/analyzer/analyzer.html
+++ b/dh_0829/analyzer/analyzer.html
@@ -97,47 +97,6 @@
         }
 
 
-        /* Fix for browser autofill styles */
-        input:-webkit-autofill,
-        input:-webkit-autofill:hover,
-        input:-webkit-autofill:focus,
-        input:-webkit-autofill:active {
-            -webkit-box-shadow: 0 0 0 30px #0D0E1B inset !important; /* Match body bg */
-            -webkit-text-fill-color: #c4c8ea !important;
-            transition: background-color 5000s ease-in-out 0s;
-            caret-color: #c4c8ea;
-        }
-
-        #usernameInput, #leagueSelect {
-            background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
-            border: 1px solid var(--color-panel-border);
-            border-radius: 8px;
-            backdrop-filter: blur(4px) saturate(110%);
-            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
-            color: #c4c8ea;
-            transition: all 0.2s ease;
-        }
-
-        #usernameInput:focus, #leagueSelect:focus {
-            outline: none;
-            border-color: var(--color-accent-primary);
-            box-shadow: 0 0 8px var(--color-accent-primary-glow);
-        }
-
-        #fetchDataButton {
-            border: 1px solid transparent;
-            border-radius: 6px;
-            cursor: pointer;
-            transition: all 0.2s ease;
-            color: var(--color-text-primary);
-            text-shadow: 0 0 2px rgba(0,0,0,0.2);
-            border-color: #766DFF;
-            box-shadow: 0 0 8px var(--color-accent-primary-glow);
-        }
-        #fetchDataButton:hover {
-             box-shadow: 0 0 12px var(--color-accent-primary-glow);
-        }
-
     </style>
 </head>
 <body class="px-2 pb-4 md:px-8 md:pb-8">
@@ -154,17 +113,6 @@
             <p class="text-md text-gray-400">KTC Team Value Analysis</p>
         </header>
 
-        <!-- Controls -->
-        <div class="glass-panel py-1 px-2 flex flex-col md:flex-row items-center justify-center gap-1">
-            <input type="text" id="usernameInput" placeholder="Enter Sleeper Username" class="px-3 py-1 text-sm w-full md:w-auto">
-            <div id="leagueSelectWrapper" class="hidden w-full md:w-auto">
-                <select id="leagueSelect" class="px-3 py-1 text-sm w-full md:w-auto appearance-none">
-                    <option>Select a league...</option>
-                </select>
-            </div>
-            <button id="fetchDataButton" class="bg-purple-600/50 hover:bg-purple-700/50 text-white font-bold text-sm py-1 px-3 w-full md:w-auto">Analyze League</button>
-        </div>
-        
         <!-- Summary Stats -->
         <section id="summaryStats" class="hidden grid grid-cols-4 lg:grid-cols-8 gap-1 md:gap-4 text-center my-2 md:my-0">
             <!-- Summary boxes injected here -->
@@ -215,14 +163,10 @@
         document.addEventListener('DOMContentLoaded', () => {
 
             // --- DOM Elements ---
-            const usernameInput = document.getElementById('usernameInput');
-            const leagueSelect = document.getElementById('leagueSelect');
-            const fetchDataButton = document.getElementById('fetchDataButton');
             const loadingIndicator = document.getElementById('loading');
             const infographicContent = document.getElementById('infographicContent');
             const starterRankingsGrid = document.getElementById('starterRankingsGrid');
             const summaryStats = document.getElementById('summaryStats');
-
 
             // --- Chart instances ---
             let overallChart, startersChart, radarChart;
@@ -248,40 +192,32 @@
                 SUPER_FLEX: 'rgba(220, 220, 220, 0.8)', // Silver
                 Picks: 'rgba(255, 199, 0, 0.8)'
             };
+            // --- Initialization ---
+            const params = new URLSearchParams(window.location.search);
+            const username = params.get('username');
+            const leagueId = params.get('leagueId');
 
+            if (username && leagueId) {
+                runAnalyzer(username, leagueId);
+            } else {
+                alert('Missing username or league ID in query string.');
+            }
 
-            // --- Event Listeners ---
-            fetchDataButton.addEventListener('click', handleFetchData);
-            leagueSelect.addEventListener('change', () => {
-                if (leagueSelect.value) {
-                    analyzeLeague(leagueSelect.value);
-                }
-            });
-
-            async function handleFetchData() {
-                const username = usernameInput.value.trim();
-                if (!username) {
-                    alert('Please enter a Sleeper username.');
-                    return;
-                }
-
+            async function runAnalyzer(username, leagueId) {
                 setLoading(true);
                 infographicContent.classList.add('hidden');
                 summaryStats.classList.add('hidden');
 
                 try {
-                    // Fetch all initial data concurrently
                     await Promise.all([
                         fetchSleeperPlayers(),
                         fetchKTCData()
                     ]);
-                    
+
                     await fetchUserAndLeagues(username);
 
                     if (state.leagues.length > 0) {
-                        // Auto-select and analyze the first league
-                        leagueSelect.selectedIndex = 1;
-                        await analyzeLeague(state.leagues[0].league_id);
+                        await analyzeLeague(leagueId);
                     }
                 } catch (error) {
                     console.error('Error fetching data:', error);
@@ -857,28 +793,11 @@
                 return '#FF3A75'; // Bottom 20%
             }
 
-            // --- UI Helpers ---
-            function populateLeagueSelect(leagues) {
-                leagueSelect.innerHTML = '<option value="">Select a league...</option>';
-                leagues.forEach(league => {
-                    const option = document.createElement('option');
-                    option.value = league.league_id;
-                    option.textContent = league.name;
-                    leagueSelect.appendChild(option);
-                });
-                document.getElementById('leagueSelectWrapper').classList.remove('hidden');
-                leagueSelect.disabled = false;
-            }
-
             function setLoading(isLoading) {
                 if (isLoading) {
                     loadingIndicator.classList.remove('hidden');
-                    fetchDataButton.disabled = true;
-                    fetchDataButton.textContent = 'Loading...';
                 } else {
                     loadingIndicator.classList.add('hidden');
-                    fetchDataButton.disabled = false;
-                    fetchDataButton.textContent = 'Analyze League';
                 }
             }
         });

--- a/dh_0829/index.html
+++ b/dh_0829/index.html
@@ -40,8 +40,7 @@
         <a href="index.html">Home</a>
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
-        <a href="#">Placeholder 1</a>
-        <a href="#">Placeholder 2</a>
+        <a href="#" id="menu-analyzer">League Analyzer</a>
     </div>
 </div>
 <div class="username-area">

--- a/dh_0829/ownership/ownership.html
+++ b/dh_0829/ownership/ownership.html
@@ -40,8 +40,7 @@
         <a href="../">Home</a>
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
-        <a href="#">Placeholder 1</a>
-        <a href="#">Placeholder 2</a>
+        <a href="#" id="menu-analyzer">League Analyzer</a>
     </div>
 </div>
 <div class="username-area">
@@ -63,6 +62,7 @@
 <button id="positionalViewBtn">Positional</button>
 <button id="depthChartViewBtn">Lineup</button>
 </div>
+<button id="analyzeLeagueBtn" class="control-button">Analyze</button>
 </div>
 <div class="header-row">
 <div id="positional-filters">

--- a/dh_0829/rosters/rosters.html
+++ b/dh_0829/rosters/rosters.html
@@ -40,8 +40,7 @@
         <a href="../">Home</a>
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
-        <a href="#">Placeholder 1</a>
-        <a href="#">Placeholder 2</a>
+        <a href="#" id="menu-analyzer">League Analyzer</a>
     </div>
 </div>
 <div class="username-area">
@@ -63,6 +62,7 @@
 <button id="positionalViewBtn">Positional</button>
 <button id="depthChartViewBtn">Lineup</button>
 </div>
+<button id="analyzeLeagueBtn" class="control-button">Analyze</button>
 </div>
 <div class="header-row">
 <div id="positional-filters">

--- a/dh_0829/scripts/app.js
+++ b/dh_0829/scripts/app.js
@@ -21,6 +21,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const clearCompareButton = document.getElementById('clearCompareButton');
         const positionalViewBtn = document.getElementById('positionalViewBtn');
         const depthChartViewBtn = document.getElementById('depthChartViewBtn');
+        const analyzeLeagueBtn = document.getElementById('analyzeLeagueBtn');
         const viewControls = document.getElementById('view-controls');
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const tradeSimulator = document.getElementById('tradeSimulator');
@@ -32,6 +33,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const dropdownMenu = document.getElementById('dropdown-menu');
         const menuRosters = document.getElementById('menu-rosters');
         const menuOwnership = document.getElementById('menu-ownership');
+        const menuAnalyzer = document.getElementById('menu-analyzer');
 
         menuButton?.addEventListener('click', (e) => {
             e.stopPropagation();
@@ -63,6 +65,15 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             } else {
                 handleFetchOwnership();
             }
+            dropdownMenu.classList.add('hidden');
+        });
+
+        menuAnalyzer?.addEventListener('click', () => {
+            const username = usernameInput.value.trim();
+            const leagueId = state.currentLeagueId || leagueSelect?.value;
+            if (!username || !leagueId) return;
+            const base = pageType === 'welcome' ? '' : '../';
+            window.location.href = `${base}analyzer/analyzer.html?username=${encodeURIComponent(username)}&leagueId=${leagueId}`;
             dropdownMenu.classList.add('hidden');
         });
 
@@ -128,6 +139,13 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
         positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
         depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
+        analyzeLeagueBtn?.addEventListener('click', () => {
+            const username = usernameInput.value.trim();
+            const leagueId = state.currentLeagueId || leagueSelect?.value;
+            if (!username || !leagueId) return;
+            const base = pageType === 'welcome' ? '' : '../';
+            window.location.href = `${base}analyzer/analyzer.html?username=${encodeURIComponent(username)}&leagueId=${leagueId}`;
+        });
         positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
         
         // --- Initialization ---
@@ -1211,7 +1229,7 @@ if ('serviceWorker' in navigator) {
 
 
 // Hide legend when switching away from Welcome via UI controls
-['rostersButton','ownershipButton','previewButton','leagueSelect','positionalViewBtn','depthChartViewBtn'].forEach(id=>{
+['rostersButton','ownershipButton','previewButton','leagueSelect','positionalViewBtn','depthChartViewBtn','analyzeLeagueBtn'].forEach(id=>{
   const el = document.getElementById(id);
   if (el) el.addEventListener('click', hideLegend, {capture:true});
 });

--- a/dh_0829/styles/styles.css
+++ b/dh_0829/styles/styles.css
@@ -289,9 +289,9 @@
         /* Row 2 */
         .custom-select-wrapper {
             position: relative;
-            flex-grow: 1;
-            min-width: 120px;
-            max-width: 150px;
+            flex-grow: 0;
+            min-width: 100px;
+            max-width: 110px;
         }
         #leagueSelect {
             appearance: none;
@@ -446,6 +446,9 @@
             transition: all 0.2s ease;
             white-space: nowrap;
             color: var(--color-text-secondary);
+        }
+        #analyzeLeagueBtn {
+            flex-shrink: 0;
         }
         .control-button.glow-on-select {
             box-shadow: 0 0 8px #7300ff;
@@ -1082,9 +1085,13 @@
                 flex-grow: 0; /* Prevents the filter group from expanding */
             }
 
-            .username-area, .custom-select-wrapper {
+            .username-area {
                 flex-grow: 0;
-                max-width: 220px;
+                max-width: 200px;
+            }
+            .custom-select-wrapper {
+                flex-grow: 0;
+                max-width: 110px;
             }
         }
 


### PR DESCRIPTION
## Summary
- Move Analyze action out of Positional/Lineup switcher
- Narrow league select to keep header row on one line
- Open analyzer with currently selected league

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b244e54424832e9b51ef28e4aa2805